### PR TITLE
Fix for edge-case when scientific notation is present transform parameter values

### DIFF
--- a/code/elastix_parameter_read.m
+++ b/code/elastix_parameter_read.m
@@ -61,7 +61,7 @@ while ischar(tline)
         tok=regexp(tline,'"(.*)"','tokens');
         value=tok{1}{1};
     else %It's a numeric value
-        tok=regexp(tline,'\w+ ([\d\. -]+)\)','tokens');
+        tok=regexp(tline,'\w+ ([\d\. -e]+)\)','tokens');
         value=str2num(tok{1}{1});
     end
     % - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Had an issue when an Affine Transform expected 12 parameters and only read the last 4 from the txt file written by elastix. The cause was that the 8th parameter contained 'e-7'.

Included 'e' to the regexp pattern in elastix_parameter_read.m to avoid skipping parameters when the values in the transform contain scientific notation.